### PR TITLE
Use a comment filter to comment ansible_managed

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ galaxy_info:
   author: Giovanni Torres
   description: Installs and configures tuned, a system tuning tool.
   license: license BSD
-  min_ansible_version: 1.6
+  min_ansible_version: 2.0
   platforms:
     - name: EL
       versions:

--- a/templates/custom_profile.conf.j2
+++ b/templates/custom_profile.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 #
 # tuned {{ tuned_active_custom_profile.name }} configuration
 #


### PR DESCRIPTION
When using a multi-lined ansible_managed comment, this template breaks.
By using the comment filter, it will comment each line of the
ansible_managed message.

See: https://docs.ansible.com/ansible/latest/user_guide/playbooks_filters.html#comment-filter

Signed-off-by: Bryan Hundven <bryanhundven@gmail.com>