### PR TITLE
Support ansible-core>=2.16.0

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,6 +23,6 @@
     - tuned_active_builtin_profile not in tuned_active.stdout
 
 - name: Build and activate custom tuned profile.
-  include: configure-custom-profile.yml
+  include_tasks: configure-custom-profile.yml
   when:
     - tuned_active_custom_profile | length > 0


### PR DESCRIPTION
- Remove use of include (instead of import_tasks/include_tasks) which
  has now been removed. See:
  https://github.com/ansible/ansible/commit/8db9bd757444fba6dd23fcb067e261d877926a33
