### PR TITLE
Use package instead of yum

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Ansible Role](https://img.shields.io/ansible/role/19447.svg)](https://galaxy.ansible.com/giovtorres/tuned/)
 
 Installs and configures the tuned daemon for setting system tuning profiles.
-Supported on EL7.
+Supported on EL7/8/9/10, and Debian/Ubuntu where tuned is available.
 
 ## Requirements
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Install tuned.
-  yum:
+  ansible.builtin.package:
     name: tuned
     state: present
 


### PR DESCRIPTION
This provides support for recent Debian-based distributions and potentially others where tuned is available.